### PR TITLE
Docs: Improve description of the plugin's scope

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Fontpack: Free fonts
 ====================
 
-This is a plugin for `pretix`_ that adds fonts to the PDF editor.
+This is a plugin for `pretix`_ that adds free fonts to the ticket shop, PDF editor and PDF invoices.
 
 Font list
 ---------

--- a/pretix_fontpackfree/apps.py
+++ b/pretix_fontpackfree/apps.py
@@ -9,7 +9,7 @@ class PluginApp(AppConfig):
     class PretixPluginMeta:
         name = 'Fontpack: Free fonts'
         author = 'Raphael Michel'
-        description = 'Pack of free fonts for pretix\' ticket editor'
+        description = 'Pack of free fonts for pretix'
         visible = False
         version = __version__
         compatibility = "pretix>=4.16.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pretix-fontpack-free"
 dynamic = ["version"]
-description = "Pack of free fonts for pretix' ticket editor"
+description = "Pack of free fonts for pretix"
 readme = "README.rst"
 requires-python = ">=3.9"
 license = {file = "LICENSE"}


### PR DESCRIPTION
I changed the plugin's description line at the top of README to make clear that this plugin also adds fonts to choose for the shop design and the invoice PDF, not only for the PDF ticket layout editor.

Further questions and proposals:

- Are there more use cases for the fonts (than these 3) that are worth to be mentioned?
- I also want to propose to:
  - Change the repository description from "Set of free fonts for pretix' ticket PDF editor" to "Set of free fonts for pretix"
  - Add the use case "PDF invoices" (and possibly others that I missed) [on the plugin's marketplace website](https://marketplace.pretix.eu/products/fontpack-free/).